### PR TITLE
Clarify debug messages: use 'gamespace ID' instead of 'event ID'

### DIFF
--- a/question.php
+++ b/question.php
@@ -398,11 +398,11 @@ class qtype_mojomatch_question extends question_graded_by_strategy
 
         $eventid = $this->get_eventid_for_attempt($qa);
         if ($eventid) {
-            debugging("Using event ID from attempt record: $eventid", DEBUG_DEVELOPER);
+            debugging("Using gamespace ID from attempt record: $eventid", DEBUG_DEVELOPER);
             return get_gamespace_challenge($client, $eventid);
         }
 
-        debugging("No event ID on attempt record, falling back to active event search", DEBUG_DEVELOPER);
+        debugging("No gamespace ID on attempt record, falling back to active gamespace search", DEBUG_DEVELOPER);
         $all_events = list_all_active_events($client);
         if (!$all_events) {
             debugging("no events", DEBUG_DEVELOPER);

--- a/version.php
+++ b/version.php
@@ -45,7 +45,7 @@ DM24-1315
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_mojomatch';
-$plugin->version   = 2026051200;
+$plugin->version   = 2026060800;
 
 // This is a list of plugins, this plugin depends on (and their versions).
 $plugin->dependencies = [


### PR DESCRIPTION
Changed debug messages in get_challenge_for_attempt() to use the more accurate term 'gamespace ID' instead of 'event ID', since this is a TopoMojo gamespace GUID, not a Moodle event.

- 'Using event ID from attempt record' → 'Using gamespace ID from attempt record'
- 'No event ID on attempt record' → 'No gamespace ID on attempt record'
- Updated follow-up message to match: 'active gamespace search' instead of 'active event search'

This improves clarity for developers debugging TopoMojo integration issues.